### PR TITLE
Add member properties for proposed fees

### DIFF
--- a/contracts/CommonsBudget.sol
+++ b/contracts/CommonsBudget.sol
@@ -2,11 +2,43 @@
 
 pragma solidity >=0.6.0 <0.9.0;
 
-contract CommonsBudget {
+import "@openzeppelin/contracts/access/Ownable.sol";
 
-    event Received(address, uint);
+contract CommonsBudget is Ownable {
+    event Received(address, uint256);
 
     receive() external payable {
         emit Received(msg.sender, msg.value);
+    }
+
+    // It is a fee for the funding proposal. This is not a unit of BOA.
+    // This is a thousand percent.
+    // Proposal Fee = Funding amount * fund_proposal_fee_permil / 1000
+    uint32 fund_proposal_fee_permil;
+
+    // It is a fee for system proposals. Its unit is cent of BOA.
+    uint256 system_proposal_fee;
+
+    constructor() {
+        fund_proposal_fee_permil = 10;
+        system_proposal_fee = 100000000000000000000;
+    }
+
+    // Proposal Fee = Funding amount * _value / 1000
+    function setFundProposalFeePermil(uint32 _value) public onlyOwner {
+        fund_proposal_fee_permil = _value;
+    }
+
+    function getFundProposalFeePermil() public view returns (uint32) {
+        return fund_proposal_fee_permil;
+    }
+
+    // Its unit is cent of BOA.
+    function setSystemProposalFee(uint256 _value) public onlyOwner {
+        system_proposal_fee = _value;
+    }
+
+    function getSystemProposalFee() public view returns (uint256) {
+        return system_proposal_fee;
     }
 }

--- a/test/CommonsBudget.test.ts
+++ b/test/CommonsBudget.test.ts
@@ -14,6 +14,7 @@ describe("Test of Commons Budget Contract", () => {
     const provider = waffle.provider;
     const [admin] = provider.getWallets();
     const amount = BigNumber.from(10).pow(18);
+    const admin_signer = provider.getSigner(admin.address);
 
     before(async () => {
         const CommonsBudgetFactory = await ethers.getContractFactory("CommonsBudget");
@@ -31,5 +32,22 @@ describe("Test of Commons Budget Contract", () => {
     it("Check", async () => {
         const balance = await provider.getBalance(contract.address);
         assert.deepStrictEqual(balance, amount);
+    });
+
+    it("Check Proposal Fee", async () => {
+        const fundProposalFee = await contract.getFundProposalFeePermil();
+        assert.deepStrictEqual(fundProposalFee.toString(), "10");
+        const systemProposalFe = await contract.getSystemProposalFee();
+        assert.deepStrictEqual(systemProposalFe.toString(), "100000000000000000000");
+    });
+
+    it("Set Proposal Fee", async () => {
+        await contract.connect(admin_signer).setFundProposalFeePermil(20);
+        await contract.connect(admin_signer).setSystemProposalFee(BigNumber.from(500).mul(BigNumber.from(10).pow(18)));
+
+        const fundProposalFee = await contract.getFundProposalFeePermil();
+        assert.deepStrictEqual(fundProposalFee.toString(), "20");
+        const systemProposalFe = await contract.getSystemProposalFee();
+        assert.deepStrictEqual(systemProposalFe.toString(), "500000000000000000000");
     });
 });


### PR DESCRIPTION
**펀딩 제안에서 사용될 수수료**
지금까지 백분률을 사용하였습니다. 그러나 소수점 1자를 고려하여 천분률의 정수형을 가지는 속성을 추가했습니다.
따라서 설정된 값은 1/100이 아니라 1/1000 입니다.

**시스템 제안에서 사용될 수수료**
보아단위의 정수형을 가지는 속성을 추가했습니다.

제안을 생성할 때 이 값을 참조하시기 바랍니다