### PR TITLE
Add a member property for vote quorum

### DIFF
--- a/contracts/CommonsBudget.sol
+++ b/contracts/CommonsBudget.sol
@@ -19,9 +19,14 @@ contract CommonsBudget is Ownable {
     // It is a fee for system proposals. Its unit is cent of BOA.
     uint256 system_proposal_fee;
 
+    // Factor required to calculate a valid quorum
+    // Quorum = Number of validators * vote_quorum_permil / 1000000
+    uint32 vote_quorum_factor;
+
     constructor() {
         fund_proposal_fee_permil = 10;
         system_proposal_fee = 100000000000000000000;
+        vote_quorum_factor = 333333; // Number of validators / 3
     }
 
     // Proposal Fee = Funding amount * _value / 1000
@@ -40,5 +45,14 @@ contract CommonsBudget is Ownable {
 
     function getSystemProposalFee() public view returns (uint256) {
         return system_proposal_fee;
+    }
+
+    // Proposal Fee = Number of validators * _value / 1000000
+    function setVoteQuorumFactor(uint32 _value) public onlyOwner {
+        vote_quorum_factor = _value;
+    }
+
+    function getVoteQuorumFactor() public view returns (uint32) {
+        return vote_quorum_factor;
     }
 }

--- a/test/CommonsBudget.test.ts
+++ b/test/CommonsBudget.test.ts
@@ -50,4 +50,15 @@ describe("Test of Commons Budget Contract", () => {
         const systemProposalFe = await contract.getSystemProposalFee();
         assert.deepStrictEqual(systemProposalFe.toString(), "500000000000000000000");
     });
+
+    it("Check Quorum Factor", async () => {
+        const factor = await contract.getVoteQuorumFactor();
+        assert.deepStrictEqual(factor, 333333);
+    });
+
+    it("Set Quorum Factor", async () => {
+        await contract.connect(admin_signer).setVoteQuorumFactor(200000);
+        const factor = await contract.getVoteQuorumFactor();
+        assert.deepStrictEqual(factor, 200000);
+    });
 });


### PR DESCRIPTION
투표시 유효한 쿼럼은 전체검증자의 1/3로 백서에 정해져 있습니다. 또한 이 값은 변경될 수 있어야 한다고 합니다.
따라서 이 값을 맴버에 추가합니다. 그리고 컨트랙트의 소유자만이 수정할 수 있게 합니다.

이 값은 소수점이하 6자리 까지 표시할 수 있게 하기 1000000를 곱한 값을 사용하도록 하였습니다.