### PR TITLE
Refactor test code

### DIFF
--- a/test/AdminAction.test.ts
+++ b/test/AdminAction.test.ts
@@ -13,13 +13,29 @@ import {
     VoteraVote,
     VoteraVote__factory as VoteraVoteFactory,
 } from "../typechain";
-import { makeCommitment, signCommitment, signFundProposal, signSystemProposal } from "./VoteHelper";
+import {
+    createSystemProposal,
+    makeCommitment,
+    setEnvironment,
+    signCommitment,
+    signFundProposal,
+    signSystemProposal,
+} from "./VoteHelper";
 
 const AddressZero = "0x0000000000000000000000000000000000000000";
-const AddressNormal = "0xcD958D25697A04B0e55BF13c5ADE051beE046354";
+const InvalidProposal = "0x43d26d775ef3a282483394ce041a2757fbf700c9cf86accc6f0ce410accf123f";
 const DocHash = "0x9f18669085971c1306dd0096ec531e71ad2732fd0e783068f2a3aba628613231";
 
 chai.use(solidity);
+
+function getNewProposal() {
+    for (;;) {
+        const proposal = `0x${crypto.randomBytes(32).toString("hex")}`;
+        if (proposal !== InvalidProposal) {
+            return proposal;
+        }
+    }
+}
 
 describe("Test actions by contract owner", () => {
     let contract: CommonsBudget;
@@ -34,7 +50,9 @@ describe("Test actions by contract owner", () => {
     const amount = BigNumber.from(10).pow(18);
     const adminSigner = provider.getSigner(admin.address);
 
-    let proposal: string;
+    let proposalID: string;
+
+    const proposer: Wallet = validators[0];
 
     before(async () => {
         const commonsBudgetFactory = await ethers.getContractFactory("CommonsBudget");
@@ -53,68 +71,51 @@ describe("Test actions by contract owner", () => {
         const voteAddress = voteraVote.address;
         const changeParamTx = await contract.changeVoteParam(voteManager.address, voteAddress);
         await changeParamTx.wait();
+
+        // set information about network, contract, and validators in helper module
+        await setEnvironment(provider, contract, voteraVote, admin, voteManager, validators);
     });
 
     beforeEach(() => {
-        proposal = `0x${crypto.randomBytes(32).toString("hex")}`;
+        // generate random proposal id (which is address type)
+        proposalID = getNewProposal();
     });
 
     it("Check if admin can distribute vote fees", async () => {
-        const blockLatest = await ethers.provider.getBlock("latest");
-        const title = "SystemProposalTitle";
-        const startTime = blockLatest.timestamp + 30000;
-        const endTime = startTime + 30000;
-        const openTime = endTime + 30;
-        const docHash = DocHash;
-        const signProposal = await signSystemProposal(voteManager, proposal, title, startTime, endTime, docHash);
-        const validatorBudget = CommonsBudgetFactory.connect(contract.address, validators[0]);
-        const makeProposalTx = await validatorBudget.createSystemProposal(
-            proposal,
-            { start: startTime, end: endTime, startAssess: 0, endAssess: 0, docHash, amount: 0, title },
-            signProposal,
-            { value: basicFee }
-        );
-        await makeProposalTx.wait();
+        await createSystemProposal(proposalID, proposer, DocHash, basicFee);
+        const proposalData = await contract.getProposalData(proposalID);
+        const startTime = proposalData.start;
+        const endTime = proposalData.end;
+        const openTime = endTime.add(30);
 
         // ready to start voting
-        const { voteAddress } = await contract.getProposalData(proposal);
-        await voteraVote.setupVoteInfo(proposal, startTime, endTime, openTime, "info");
+        await voteraVote.setupVoteInfo(proposalID, startTime, endTime, openTime, "info");
 
         // add only half of validators
         const validators1 = validators.slice(0, validators.length / 2);
         const validators2 = validators.slice(validators1.length, validators.length);
         await voteraVote.addValidators(
-            proposal,
+            proposalID,
             validators1.map((v) => v.address),
             false
         );
-        expect(await contract.connect(adminSigner).canDistributeVoteFees(proposal)).equal(false);
+        expect(await contract.connect(adminSigner).canDistributeVoteFees(proposalID)).equal(false);
 
         // add all the validators
         await voteraVote.addValidators(
-            proposal,
+            proposalID,
             validators2.map((v) => v.address),
             true
         );
-        expect(await contract.connect(adminSigner).canDistributeVoteFees(proposal)).equal(true);
+        expect(await contract.connect(adminSigner).canDistributeVoteFees(proposalID)).equal(true);
     });
 
     it("Distribute fees to more than 500 validators", async () => {
-        const blockLatest = await ethers.provider.getBlock("latest");
-        const title = "SystemProposalTitle";
-        const startTime = blockLatest.timestamp + 30000;
-        const endTime = startTime + 30000;
-        const openTime = endTime + 30;
-        const docHash = DocHash;
-        const signProposal = await signSystemProposal(voteManager, proposal, title, startTime, endTime, docHash);
-        const validatorBudget = CommonsBudgetFactory.connect(contract.address, validators[0]);
-        const makeProposalTx = await validatorBudget.createSystemProposal(
-            proposal,
-            { start: startTime, end: endTime, startAssess: 0, endAssess: 0, docHash, amount: 0, title },
-            signProposal,
-            { value: basicFee }
-        );
-        await makeProposalTx.wait();
+        await createSystemProposal(proposalID, proposer, DocHash, basicFee);
+        const proposalData = await contract.getProposalData(proposalID);
+        const startTime = proposalData.start;
+        const endTime = proposalData.end;
+        const openTime = endTime.add(30);
 
         // create more validators and have 108 validators in total
         let manyValidators: Wallet[] = validators;
@@ -124,19 +125,19 @@ describe("Test actions by contract owner", () => {
         }
 
         // ready to start voting
-        const { voteAddress } = await contract.getProposalData(proposal);
-        await voteraVote.setupVoteInfo(proposal, startTime, endTime, openTime, "info");
+        const { voteAddress } = await contract.getProposalData(proposalID);
+        await voteraVote.setupVoteInfo(proposalID, startTime, endTime, openTime, "info");
         const count = Math.floor(manyValidators.length / 100);
         for (let i = 0; i < count; i += 1) {
             const start = i * 100;
             await voteraVote.addValidators(
-                proposal,
+                proposalID,
                 manyValidators.slice(start, start + 100).map((v) => v.address),
                 false
             );
         }
         await voteraVote.addValidators(
-            proposal,
+            proposalID,
             manyValidators.slice(addCount, manyValidators.length).map((v) => v.address),
             true
         );
@@ -144,10 +145,10 @@ describe("Test actions by contract owner", () => {
         // get validators' balances to be compared with their balances after paying fees
         const prevBalances = new Map<string, BigNumber>();
         const valAddresses: string[] = [];
-        const validatorCount = await voteraVote.getValidatorCount(proposal);
+        const validatorCount = await voteraVote.getValidatorCount(proposalID);
         const valAddressLength = validatorCount.toNumber();
         for (let i = 0; i < valAddressLength; i += 1) {
-            valAddresses.push(await voteraVote.getValidatorAt(proposal, i));
+            valAddresses.push(await voteraVote.getValidatorAt(proposalID, i));
         }
         expect(valAddresses.length).equals(manyValidators.length);
         for (const address of valAddresses) {
@@ -160,7 +161,7 @@ describe("Test actions by contract owner", () => {
         const distCallCount = valAddresses.length / maxCountDist;
         for (let i = 0; i < distCallCount; i += 1) {
             const start = i * maxCountDist;
-            await contract.distributeVoteFees(proposal, start);
+            await contract.distributeVoteFees(proposalID, start);
             await network.provider.send("evm_mine");
         }
 
@@ -177,7 +178,7 @@ describe("Test actions by contract owner", () => {
         // try to distribute vote fess to validators AGAIN
         for (let i = 0; i < distCallCount; i += 1) {
             const start = i * maxCountDist;
-            await contract.distributeVoteFees(proposal, start);
+            await contract.distributeVoteFees(proposalID, start);
             await network.provider.send("evm_mine");
         }
 

--- a/test/FundWithdrawal.test.ts
+++ b/test/FundWithdrawal.test.ts
@@ -11,31 +11,22 @@ import {
     VoteraVote,
     VoteraVote__factory as VoteraVoteFactory,
 } from "../typechain";
-import { makeCommitment, signCommitment, signFundProposal, signSystemProposal } from "./VoteHelper";
-
-import * as assert from "assert";
+import {
+    assessProposal,
+    countVote,
+    countVoteResult,
+    createFundProposal,
+    createSystemProposal,
+    makeCommitment,
+    setEnvironment,
+    signCommitment,
+} from "./VoteHelper";
 
 const AddressZero = "0x0000000000000000000000000000000000000000";
 const InvalidProposal = "0x43d26d775ef3a282483394ce041a2757fbf700c9cf86accc6f0ce410accf123f";
 const DocHash = "0x9f18669085971c1306dd0096ec531e71ad2732fd0e783068f2a3aba628613231";
 
 chai.use(solidity);
-
-function toSystemInput(title: string, start: number, end: number, docHash: BytesLike) {
-    return { start, end, startAssess: 0, endAssess: 0, docHash, amount: 0, title };
-}
-
-function toFundInput(
-    title: string,
-    start: number,
-    end: number,
-    startAssess: number,
-    endAssess: number,
-    docHash: BytesLike,
-    amount: BigNumberish
-) {
-    return { start, end, startAssess, endAssess, docHash, amount, title };
-}
 
 function getNewProposal() {
     for (;;) {
@@ -57,19 +48,13 @@ describe("Test of Fund Withdrawal", () => {
     let voteraVote: VoteraVote;
 
     const { provider } = waffle;
-    const [admin, voteManager, ...richValidators] = provider.getWallets();
+    const [admin, voteManager, ...validators] = provider.getWallets();
     const adminSigner = provider.getSigner(admin.address);
     const basicFee = ethers.utils.parseEther("100.0");
     const fundAmount = ethers.utils.parseEther("10000.0");
 
     let proposalID: string;
-
-    // create more validators and have 100 validators in total
-    let validators: Wallet[] = [];
-    validators = validators.concat(richValidators);
-    for (let i = validators.length; i < 100; i += 1) {
-        validators = validators.concat(provider.createEmptyWallet());
-    }
+    const proposer: Wallet = validators[0];
 
     before(async () => {
         // deploy CommonsBudget
@@ -90,10 +75,13 @@ describe("Test of Fund Withdrawal", () => {
         const changeParamTx = await commonsBudget.changeVoteParam(voteManager.address, voteraVote.address);
         await changeParamTx.wait();
 
+        // set information about network, contract, and validators in helper module
+        await setEnvironment(provider, commonsBudget, voteraVote, admin, voteManager, validators);
+
         // send 1 million BOA to CommonsBudget contract
         const commonsFund = BigNumber.from(10).pow(18).mul(500000);
         for (let i = 0; i < 2; i++) {
-            await provider.getSigner(richValidators[i].address).sendTransaction({
+            await provider.getSigner(validators[i].address).sendTransaction({
                 to: commonsBudget.address,
                 value: commonsFund,
             });
@@ -105,182 +93,8 @@ describe("Test of Fund Withdrawal", () => {
         proposalID = getNewProposal();
     });
 
-    const createSystemProposal = async () => {
-        const blockLatest = await ethers.provider.getBlock("latest");
-        const title = "SystemProposalTitle";
-        const startTime = blockLatest.timestamp + 30000;
-        const endTime = startTime + 30000;
-        const docHash = DocHash;
-        const signProposal = await signSystemProposal(voteManager, proposalID, title, startTime, endTime, docHash);
-
-        const proposerBudget = CommonsBudgetFactory.connect(commonsBudget.address, validators[0]);
-        const makeProposalTx = await proposerBudget.createSystemProposal(
-            proposalID,
-            toSystemInput(title, startTime, endTime, docHash),
-            signProposal,
-            { value: basicFee }
-        );
-        await makeProposalTx.wait();
-    };
-
-    const createFundProposal = async () => {
-        const blockLatest = await ethers.provider.getBlock("latest");
-        const title = "FundProposalTitle";
-        const startAssess = blockLatest.timestamp;
-        const endAssess = startAssess + 15000;
-        const startTime = blockLatest.timestamp + 30000;
-        const endTime = startTime + 30000;
-        const docHash = DocHash;
-        const proposer = validators[0].address;
-        const signProposal = await signFundProposal(
-            voteManager,
-            proposalID,
-            title,
-            startTime,
-            endTime,
-            startAssess,
-            endAssess,
-            docHash,
-            fundAmount,
-            proposer
-        );
-
-        const proposerBudget = CommonsBudgetFactory.connect(commonsBudget.address, validators[0]);
-        const makeProposalTx = await proposerBudget.createFundProposal(
-            proposalID,
-            toFundInput(title, startTime, endTime, startAssess, endAssess, docHash, fundAmount),
-            signProposal,
-            { value: basicFee }
-        );
-        await makeProposalTx.wait();
-    };
-
-    const assessProposal = async (assessResult: boolean) => {
-        const proposalData = await commonsBudget.getProposalData(proposalID);
-        const startTime = proposalData.start;
-        const endTime = proposalData.end;
-        const openTime = endTime.add(30);
-
-        await voteraVote.setupVoteInfo(proposalID, startTime, endTime, openTime, "info");
-        await voteraVote.addValidators(
-            proposalID,
-            validators.map((v) => v.address),
-            true
-        );
-
-        // distribute vote fess to validators
-        const maxCountDist = (await commonsStorage.vote_fee_distrib_count()).toNumber();
-        // const maxCountDist = (await commonsBudget.connect(adminSigner).vote_fee_distrib_count()).toNumber();
-        const distCallCount = validators.length / maxCountDist;
-        for (let i = 0; i < distCallCount; i += 1) {
-            const start = i * maxCountDist;
-            await commonsBudget.distributeVoteFees(proposalID, start);
-            await network.provider.send("evm_mine");
-        }
-
-        let assessCount: number;
-        let passAssessResult: number[] = [];
-        if (assessResult) {
-            assessCount = 2;
-            passAssessResult = [7, 7, 7, 7, 7];
-        } else {
-            assessCount = 2;
-            passAssessResult = [6, 6, 6, 6, 6];
-        }
-
-        // Fund proposal
-        if (proposalData.proposalType === 1) {
-            for (let i = 0; i < assessCount; i += 1) {
-                const assessVote = VoteraVoteFactory.connect(voteraVote.address, validators[i]);
-                await assessVote.submitAssess(proposalID, passAssessResult);
-            }
-
-            // wait unit assessEnd
-            await network.provider.send("evm_increaseTime", [15000]);
-            await network.provider.send("evm_mine");
-
-            await voteraVote.countAssess(proposalID);
-
-            // wait until startTime
-            await network.provider.send("evm_increaseTime", [15000]);
-            await network.provider.send("evm_mine");
-        } else {
-            // wait until startTime
-            await network.provider.send("evm_increaseTime", [30000]);
-            await network.provider.send("evm_mine");
-        }
-    };
-
-    const countVote = async (positive: number, negative: number, blank: number) => {
-        const voterCount = positive + negative + blank;
-
-        // setup votes
-        const choices: number[] = [];
-        const nonces: number[] = [];
-
-        // set positive votes
-        for (let i = 0; i < positive; i += 1) {
-            choices.push(1);
-            nonces.push(i + 1);
-        }
-
-        // set negative votes
-        for (let i = positive; i < positive + negative; i += 1) {
-            choices.push(2);
-            nonces.push(i + 1);
-        }
-
-        // set blank (= abstention) votes
-        for (let i = positive + negative; i < voterCount; i += 1) {
-            choices.push(0);
-            nonces.push(i + 1);
-        }
-
-        let submitBallotTx;
-        for (let i = 0; i < voterCount; i += 1) {
-            const commitment = await makeCommitment(
-                voteraVote.address,
-                proposalID,
-                validators[i].address,
-                choices[i],
-                nonces[i]
-            );
-            const signature = await signCommitment(voteManager, proposalID, validators[i].address, commitment);
-
-            const ballotVote = VoteraVoteFactory.connect(voteraVote.address, validators[i]);
-            submitBallotTx = await ballotVote.submitBallot(proposalID, commitment, signature);
-        }
-
-        expect(await voteraVote.getBallotCount(proposalID)).equal(voterCount);
-
-        if (submitBallotTx) {
-            await submitBallotTx.wait();
-        }
-
-        await network.provider.send("evm_increaseTime", [30000]);
-        await network.provider.send("evm_mine");
-
-        for (let i = 0; i < voterCount; i += 1) {
-            const ballotAddr = await voteraVote.getBallotAt(proposalID, i);
-            const ballot = await voteraVote.getBallot(proposalID, ballotAddr);
-            expect(ballot.key).equal(validators[i].address);
-        }
-
-        // wait until openTime
-        await network.provider.send("evm_increaseTime", [30]);
-        await network.provider.send("evm_mine");
-
-        await voteraVote.revealBallot(
-            proposalID,
-            validators.slice(0, voterCount).map((v) => v.address),
-            choices,
-            nonces
-        );
-        await voteraVote.countVote(proposalID);
-    };
-
     it("Withdrawal: Unable to withdraw due to W02", async () => {
-        await createSystemProposal();
+        await createSystemProposal(proposalID, proposer, DocHash, basicFee);
 
         // "W02" : The proposal is not a fund proposal
         const proposerBudget = CommonsBudgetFactory.connect(commonsBudget.address, validators[0]);
@@ -293,8 +107,8 @@ describe("Test of Fund Withdrawal", () => {
         const proposerBudget = CommonsBudgetFactory.connect(commonsBudget.address, validators[0]);
         const fakeValidatorBudget = CommonsBudgetFactory.connect(commonsBudget.address, validators[1]);
 
-        await createFundProposal();
-        await assessProposal(true);
+        await createFundProposal(proposalID, proposer, DocHash, basicFee, fundAmount);
+        await assessProposal(proposalID, true);
 
         // "W01" : There's no proposal for the proposal ID
         let [stateCode, _] = await proposerBudget.checkWithdrawState(InvalidProposal);
@@ -306,9 +120,8 @@ describe("Test of Fund Withdrawal", () => {
         expect(stateCode).equals("W04");
         await expect(commonsBudget.withdraw(proposalID)).to.revertedWith("W04");
 
-        // Vote counting finished
-        // Positive: 18, Negative: 15, Blank: 0
-        await countVote(18, 15, 0);
+        // Vote counting finished with rejection
+        await countVoteResult(proposalID, false);
 
         // "W05" : The requester of the funding is not the proposer
         [stateCode, _] = await fakeValidatorBudget.checkWithdrawState(proposalID);
@@ -323,12 +136,11 @@ describe("Test of Fund Withdrawal", () => {
 
     it("Withdrawal: First unable to withdraw due to W07 but finally can do", async () => {
         const proposerBudget = CommonsBudgetFactory.connect(commonsBudget.address, validators[0]);
-        await createFundProposal();
-        await assessProposal(true);
+        await createFundProposal(proposalID, proposer, DocHash, basicFee, fundAmount);
+        await assessProposal(proposalID, true);
 
-        // Vote counting finished
-        // Positive: 42, Negative: 34, Blank: 4
-        await countVote(42, 34, 4);
+        // Vote counting finished with approval
+        await countVoteResult(proposalID, true);
 
         // "W07" : 24 hours has not passed after the voting finished
         let [stateCode, _] = await proposerBudget.checkWithdrawState(proposalID);
@@ -367,24 +179,22 @@ describe("Test of Fund Withdrawal", () => {
 
     it("Withdrawal: Refuse funding with UNAUTHORIZED", async () => {
         const proposerBudget = CommonsBudgetFactory.connect(commonsBudget.address, validators[0]);
-        await createSystemProposal();
-        await assessProposal(true);
+        await createSystemProposal(proposalID, proposer, DocHash, basicFee);
+        await assessProposal(proposalID, true);
 
-        // Vote counting finished
-        // Positive: 42, Negative: 34, Blank: 4
-        await countVote(42, 34, 4);
+        // Vote counting finished with approval
+        await countVoteResult(proposalID, true);
 
         // refuse funding
         await expect(proposerBudget.refuseFunding(proposalID)).to.be.revertedWith("Ownable: caller is not the owner");
     });
 
     it("Withdrawal: Refuse funding for a system proposal", async () => {
-        await createSystemProposal();
-        await assessProposal(true);
+        await createSystemProposal(proposalID, proposer, DocHash, basicFee);
+        await assessProposal(proposalID, true);
 
-        // Vote counting finished
-        // Positive: 42, Negative: 34, Blank: 4
-        await countVote(42, 34, 4);
+        // Vote counting finished with approval
+        await countVoteResult(proposalID, true);
 
         // refuse funding
         await expect(commonsBudget.refuseFunding(proposalID)).to.be.revertedWith("InvalidProposal");
@@ -392,12 +202,11 @@ describe("Test of Fund Withdrawal", () => {
 
     it("Withdrawal: Refuse funding", async () => {
         const proposerBudget = CommonsBudgetFactory.connect(commonsBudget.address, validators[0]);
-        await createFundProposal();
-        await assessProposal(true);
+        await createFundProposal(proposalID, proposer, DocHash, basicFee, fundAmount);
+        await assessProposal(proposalID, true);
 
-        // Vote counting finished
-        // Positive: 42, Negative: 34, Blank: 4
-        await countVote(42, 34, 4);
+        // Vote counting finished with approval
+        await countVoteResult(proposalID, true);
 
         // 12 hours passed
         await network.provider.send("evm_increaseTime", [43200]);
@@ -417,12 +226,11 @@ describe("Test of Fund Withdrawal", () => {
 
     it("Withdrawal: Allow funding after refusing and try to refuse again after funding", async () => {
         const proposerBudget = CommonsBudgetFactory.connect(commonsBudget.address, validators[0]);
-        await createFundProposal();
-        await assessProposal(true);
+        await createFundProposal(proposalID, proposer, DocHash, basicFee, fundAmount);
+        await assessProposal(proposalID, true);
 
-        // Vote counting finished
-        // Positive: 42, Negative: 34, Blank: 4
-        await countVote(42, 34, 4);
+        // Vote counting finished with approval
+        await countVoteResult(proposalID, true);
 
         // 12 hours passed
         await network.provider.send("evm_increaseTime", [43200]);

--- a/test/VoteDecision.test.ts
+++ b/test/VoteDecision.test.ts
@@ -11,9 +11,14 @@ import {
     VoteraVote,
     VoteraVote__factory as VoteraVoteFactory,
 } from "../typechain";
-import { makeCommitment, signCommitment, signFundProposal, signSystemProposal } from "./VoteHelper";
-
-import * as assert from "assert";
+import {
+    createFundProposal,
+    createSystemProposal,
+    makeCommitment,
+    processVote,
+    setEnvironment,
+    signCommitment,
+} from "./VoteHelper";
 
 const AddressZero = "0x0000000000000000000000000000000000000000";
 const InvalidProposal = "0x43d26d775ef3a282483394ce041a2757fbf700c9cf86accc6f0ce410accf123f";
@@ -23,18 +28,6 @@ chai.use(solidity);
 
 function toSystemInput(title: string, start: number, end: number, docHash: BytesLike) {
     return { start, end, startAssess: 0, endAssess: 0, docHash, amount: 0, title };
-}
-
-function toFundInput(
-    title: string,
-    start: number,
-    end: number,
-    startAssess: number,
-    endAssess: number,
-    docHash: BytesLike,
-    amount: BigNumberish
-) {
-    return { start, end, startAssess, endAssess, docHash, amount, title };
 }
 
 function getNewProposal() {
@@ -64,15 +57,14 @@ describe("Test of Vote Decision", () => {
 
     let proposalID: string;
 
-    const assessCount = 2;
-    const passAssessResult = [7, 7, 7, 7, 7];
-
     // create more validators and have 100 validators in total
     let validators: Wallet[] = [];
     validators = validators.concat(richValidators);
     for (let i = validators.length; i < 100; i += 1) {
         validators = validators.concat(provider.createEmptyWallet());
     }
+
+    const proposer: Wallet = validators[0];
 
     before(async () => {
         // deploy CommonsBudget
@@ -93,6 +85,9 @@ describe("Test of Vote Decision", () => {
         const changeParamTx = await commonsBudget.changeVoteParam(voteManager.address, voteraVote.address);
         await changeParamTx.wait();
 
+        // set information about network, contract, and validators in helper module
+        await setEnvironment(provider, commonsBudget, voteraVote, admin, voteManager, validators);
+
         // send 1 million BOA to CommonsBudget contract
         const commonsFund = BigNumber.from(10).pow(18).mul(500000);
         for (let i = 0; i < 2; i++) {
@@ -108,169 +103,11 @@ describe("Test of Vote Decision", () => {
         proposalID = getNewProposal();
     });
 
-    const createSystemProposal = async () => {
-        const blockLatest = await ethers.provider.getBlock("latest");
-        const title = "SystemProposalTitle";
-        const startTime = blockLatest.timestamp + 30000;
-        const endTime = startTime + 30000;
-        const docHash = DocHash;
-        const signProposal = await signSystemProposal(voteManager, proposalID, title, startTime, endTime, docHash);
-
-        const proposerBudget = CommonsBudgetFactory.connect(commonsBudget.address, validators[0]);
-        const makeProposalTx = await proposerBudget.createSystemProposal(
-            proposalID,
-            toSystemInput(title, startTime, endTime, docHash),
-            signProposal,
-            { value: basicFee }
-        );
-        await makeProposalTx.wait();
-    };
-
-    const createFundProposal = async () => {
-        const blockLatest = await ethers.provider.getBlock("latest");
-        const title = "FundProposalTitle";
-        const startAssess = blockLatest.timestamp;
-        const endAssess = startAssess + 15000;
-        const startTime = blockLatest.timestamp + 30000;
-        const endTime = startTime + 30000;
-        const docHash = DocHash;
-        const proposer = validators[0].address;
-        const signProposal = await signFundProposal(
-            voteManager,
-            proposalID,
-            title,
-            startTime,
-            endTime,
-            startAssess,
-            endAssess,
-            docHash,
-            fundAmount,
-            proposer
-        );
-
-        const proposerBudget = CommonsBudgetFactory.connect(commonsBudget.address, validators[0]);
-        const makeProposalTx = await proposerBudget.createFundProposal(
-            proposalID,
-            toFundInput(title, startTime, endTime, startAssess, endAssess, docHash, fundAmount),
-            signProposal,
-            { value: basicFee }
-        );
-        await makeProposalTx.wait();
-    };
-
-    const processVote = async (positive: number, negative: number, blank: number) => {
-        const proposalData = await commonsBudget.getProposalData(proposalID);
-        const startTime = proposalData.start;
-        const endTime = proposalData.end;
-        const openTime = endTime.add(30);
-        const voterCount = positive + negative + blank;
-        await voteraVote.setupVoteInfo(proposalID, startTime, endTime, openTime, "info");
-        await voteraVote.addValidators(
-            proposalID,
-            validators.map((v) => v.address),
-            true
-        );
-
-        // distribute vote fess to validators
-        const maxCountDist = (await commonsStorage.vote_fee_distrib_count()).toNumber();
-        // const maxCountDist = (await commonsBudget.connect(adminSigner).vote_fee_distrib_count()).toNumber();
-        const distCallCount = validators.length / maxCountDist;
-        for (let i = 0; i < distCallCount; i += 1) {
-            const start = i * maxCountDist;
-            await commonsBudget.distributeVoteFees(proposalID, start);
-            await network.provider.send("evm_mine");
-        }
-
-        // Fund proposal
-        if (proposalData.proposalType === 1) {
-            for (let i = 0; i < assessCount; i += 1) {
-                const assessVote = VoteraVoteFactory.connect(voteraVote.address, validators[i]);
-                await assessVote.submitAssess(proposalID, passAssessResult);
-            }
-            // wait unit assessEnd
-            await network.provider.send("evm_increaseTime", [15000]);
-            await network.provider.send("evm_mine");
-
-            await voteraVote.countAssess(proposalID);
-
-            // wait until startTime
-            await network.provider.send("evm_increaseTime", [15000]);
-            await network.provider.send("evm_mine");
-        } else {
-            // wait until startTime
-            await network.provider.send("evm_increaseTime", [30000]);
-            await network.provider.send("evm_mine");
-        }
-
-        // setup votes
-        const choices: number[] = [];
-        const nonces: number[] = [];
-
-        // set positive votes
-        for (let i = 0; i < positive; i += 1) {
-            choices.push(1);
-            nonces.push(i + 1);
-        }
-
-        // set negative votes
-        for (let i = positive; i < positive + negative; i += 1) {
-            choices.push(2);
-            nonces.push(i + 1);
-        }
-
-        // set blank (= abstention) votes
-        for (let i = positive + negative; i < voterCount; i += 1) {
-            choices.push(0);
-            nonces.push(i + 1);
-        }
-
-        let submitBallotTx;
-        for (let i = 0; i < voterCount; i += 1) {
-            const commitment = await makeCommitment(
-                voteraVote.address,
-                proposalID,
-                validators[i].address,
-                choices[i],
-                nonces[i]
-            );
-            const signature = await signCommitment(voteManager, proposalID, validators[i].address, commitment);
-            const ballotVote = VoteraVoteFactory.connect(voteraVote.address, validators[i]);
-            submitBallotTx = await ballotVote.submitBallot(proposalID, commitment, signature);
-        }
-
-        expect(await voteraVote.getBallotCount(proposalID)).equal(voterCount);
-
-        if (submitBallotTx) {
-            await submitBallotTx.wait();
-        }
-
-        await network.provider.send("evm_increaseTime", [30000]);
-        await network.provider.send("evm_mine");
-
-        for (let i = 0; i < voterCount; i += 1) {
-            const ballotAddr = await voteraVote.getBallotAt(proposalID, i);
-            const ballot = await voteraVote.getBallot(proposalID, ballotAddr);
-            expect(ballot.key).equal(validators[i].address);
-        }
-
-        // wait until openTime
-        await network.provider.send("evm_increaseTime", [30]);
-        await network.provider.send("evm_mine");
-
-        await voteraVote.revealBallot(
-            proposalID,
-            validators.slice(0, voterCount).map((v) => v.address),
-            choices,
-            nonces
-        );
-        await voteraVote.countVote(proposalID);
-    };
-
     it("finishVote: Proposal is approved", async () => {
-        await createFundProposal();
+        await createFundProposal(proposalID, proposer, DocHash, basicFee, fundAmount);
 
         const blockLatest = await ethers.provider.getBlock("latest");
-        await processVote(50, 0, 0);
+        await processVote(proposalID, 50, 0, 0);
 
         const proposalData = await commonsBudget.getProposalData(proposalID);
         expect(proposalData.state).equal(4); // FINISHED
@@ -284,8 +121,8 @@ describe("Test of Vote Decision", () => {
     // Abstention(기권): 3
     // Voting is approved with a quorum of one-third of validators.
     it("finishVote: System proposal approved with a proper quorum", async () => {
-        await createSystemProposal();
-        await processVote(20, 10, 3);
+        await createSystemProposal(proposalID, proposer, DocHash, basicFee);
+        await processVote(proposalID, 20, 10, 3);
 
         const voteBudget = CommonsBudgetFactory.connect(commonsBudget.address, voteManager);
         const proposalData = await voteBudget.getProposalData(proposalID);
@@ -299,8 +136,8 @@ describe("Test of Vote Decision", () => {
     // Abstention(기권): 2
     // Voting is rejected because the voting count(=32) is less than the quorum(=33).
     it("finishVote: Rejected due to lack of quorum", async () => {
-        await createFundProposal();
-        await processVote(20, 10, 2);
+        await createFundProposal(proposalID, proposer, DocHash, basicFee, fundAmount);
+        await processVote(proposalID, 20, 10, 2);
 
         const voteBudget = CommonsBudgetFactory.connect(commonsBudget.address, voteManager);
         const proposalData = await voteBudget.getProposalData(proposalID);
@@ -315,8 +152,8 @@ describe("Test of Vote Decision", () => {
     // Voting is rejected because the ratio of difference between approval and rejection
     // to the quorum is less than 0.01.
     it("finishVote: Rejected due to insufficient approval votes", async () => {
-        await createFundProposal();
-        await processVote(18, 15, 0);
+        await createFundProposal(proposalID, proposer, DocHash, basicFee, fundAmount);
+        await processVote(proposalID, 18, 15, 0);
 
         const voteBudget = CommonsBudgetFactory.connect(commonsBudget.address, voteManager);
         const proposalData = await voteBudget.getProposalData(proposalID);
@@ -331,8 +168,8 @@ describe("Test of Vote Decision", () => {
     // Voting is rejected because the number of positive votes is the same as
     // the number of negative ones
     it("finishVote: Rejected with too many negative votes", async () => {
-        await createFundProposal();
-        await processVote(33, 33, 14);
+        await createFundProposal(proposalID, proposer, DocHash, basicFee, fundAmount);
+        await processVote(proposalID, 33, 33, 14);
 
         const voteBudget = CommonsBudgetFactory.connect(commonsBudget.address, voteManager);
         const proposalData = await voteBudget.getProposalData(proposalID);
@@ -346,8 +183,8 @@ describe("Test of Vote Decision", () => {
     // Abstention(기권): 13
     // Voting is rejected because negative votes are more than positive ones
     it("finishVote: Rejected with too many negative votes", async () => {
-        await createFundProposal();
-        await processVote(33, 34, 13);
+        await createFundProposal(proposalID, proposer, DocHash, basicFee, fundAmount);
+        await processVote(proposalID, 33, 34, 13);
 
         const voteBudget = CommonsBudgetFactory.connect(commonsBudget.address, voteManager);
         const proposalData = await voteBudget.getProposalData(proposalID);
@@ -362,8 +199,8 @@ describe("Test of Vote Decision", () => {
     // Voting is approved because the ratio of the difference between positive votes
     // and negative votes to the quorum is more than 0.01.
     it("finishVote: Approved with approval votes with more than 10 percent", async () => {
-        await createFundProposal();
-        await processVote(42, 34, 4);
+        await createFundProposal(proposalID, proposer, DocHash, basicFee, fundAmount);
+        await processVote(proposalID, 42, 34, 4);
 
         const voteBudget = CommonsBudgetFactory.connect(commonsBudget.address, voteManager);
         const proposalData = await voteBudget.getProposalData(proposalID);

--- a/test/VoteHelper.ts
+++ b/test/VoteHelper.ts
@@ -1,7 +1,42 @@
 /* eslint-disable no-underscore-dangle */
+import { expect } from "chai";
 import crypto from "crypto";
-import { BigNumberish, Wallet } from "ethers";
-import { ethers } from "hardhat";
+import { MockProvider } from "ethereum-waffle";
+import { BigNumber, BigNumberish, BytesLike, Wallet } from "ethers";
+import { ethers, network } from "hardhat";
+import {
+    CommonsBudget,
+    CommonsBudget__factory as CommonsBudgetFactory,
+    CommonsStorage,
+    CommonsStorage__factory as CommonsStorageFactory,
+    VoteraVote,
+    VoteraVote__factory as VoteraVoteFactory,
+} from "../typechain";
+
+function toSystemInput(title: string, start: number, end: number, docHash: BytesLike) {
+    return { start, end, startAssess: 0, endAssess: 0, docHash, amount: 0, title };
+}
+
+let provider: MockProvider;
+let commonsBudget: CommonsBudget;
+let commonsStorage: CommonsStorage;
+let voteraVote: VoteraVote;
+let commonsAddress: string;
+let admin: Wallet;
+let voteManager: Wallet;
+let validators: Wallet[];
+
+function toFundInput(
+    title: string,
+    start: number,
+    end: number,
+    startAssess: number,
+    endAssess: number,
+    docHash: BytesLike,
+    amount: BigNumberish
+) {
+    return { start, end, startAssess, endAssess, docHash, amount, title };
+}
 
 export function getHash(body: string): string {
     const hash = crypto.createHash("sha256");
@@ -76,4 +111,233 @@ export function signCommitment(
 export async function displayBalance(address: string, message: string) {
     const balance = await ethers.provider.getBalance(address);
     console.log(`${message}_balance = ${balance.toString()}`);
+}
+
+export async function setEnvironment(
+    _provider: MockProvider,
+    _commonsBudget: CommonsBudget,
+    _voteraVote: VoteraVote,
+    _admin: Wallet,
+    _voteManager: Wallet,
+    _validators: Wallet[]
+) {
+    provider = _provider;
+    commonsBudget = _commonsBudget;
+    const storageAddress = await commonsBudget.getStorageContractAddress();
+    const storageFactory = await ethers.getContractFactory("CommonsStorage");
+    commonsStorage = await storageFactory.attach(storageAddress);
+    voteraVote = _voteraVote;
+    commonsAddress = _commonsBudget.address;
+    admin = _admin;
+    voteManager = _voteManager;
+    validators = _validators;
+}
+
+export async function createSystemProposal(proposalID: string, proposer: Wallet, docHash: string, basicFee: BigNumber) {
+    const blockLatest = await ethers.provider.getBlock("latest");
+    const title = "SystemProposalTitle";
+    const startTime = blockLatest.timestamp + 30000;
+    const endTime = startTime + 30000;
+    const signProposal = await signSystemProposal(voteManager, proposalID, title, startTime, endTime, docHash);
+
+    const proposerBudget = CommonsBudgetFactory.connect(commonsAddress, proposer);
+    const makeProposalTx = await proposerBudget.createSystemProposal(
+        proposalID,
+        toSystemInput(title, startTime, endTime, docHash),
+        signProposal,
+        { value: basicFee }
+    );
+    await makeProposalTx.wait();
+}
+
+export async function createFundProposal(
+    proposalID: string,
+    proposer: Wallet,
+    docHash: string,
+    basicFee: BigNumber,
+    fundAmount: BigNumber
+) {
+    const blockLatest = await ethers.provider.getBlock("latest");
+    const title = "FundProposalTitle";
+    const startAssess = blockLatest.timestamp;
+    const endAssess = startAssess + 15000;
+    const startTime = blockLatest.timestamp + 30000;
+    const endTime = startTime + 30000;
+    const signProposal = await signFundProposal(
+        voteManager,
+        proposalID,
+        title,
+        startTime,
+        endTime,
+        startAssess,
+        endAssess,
+        docHash,
+        fundAmount,
+        proposer.address
+    );
+
+    const proposerBudget = CommonsBudgetFactory.connect(commonsAddress, proposer);
+    const makeProposalTx = await proposerBudget.createFundProposal(
+        proposalID,
+        toFundInput(title, startTime, endTime, startAssess, endAssess, docHash, fundAmount),
+        signProposal,
+        { value: basicFee }
+    );
+    await makeProposalTx.wait();
+}
+
+export async function assessProposal(proposalID: string, assessResult: boolean) {
+    const proposalData = await commonsBudget.getProposalData(proposalID);
+    const startTime = proposalData.start;
+    const endTime = proposalData.end;
+    const openTime = endTime.add(30);
+
+    await voteraVote.setupVoteInfo(proposalID, startTime, endTime, openTime, "info");
+    await voteraVote.addValidators(
+        proposalID,
+        validators.map((v) => v.address),
+        true
+    );
+
+    // distribute vote fess to validators
+    const adminSigner = provider.getSigner(admin.address);
+    const maxCountDist = (await commonsStorage.vote_fee_distrib_count()).toNumber();
+    const distCallCount = validators.length / maxCountDist;
+    for (let i = 0; i < distCallCount; i += 1) {
+        const start = i * maxCountDist;
+        await commonsBudget.distributeVoteFees(proposalID, start);
+        await network.provider.send("evm_mine");
+    }
+
+    let assessCount: number;
+    let passAssessResult: number[] = [];
+    if (assessResult) {
+        assessCount = 2;
+        passAssessResult = [7, 7, 7, 7, 7];
+    } else {
+        assessCount = 2;
+        passAssessResult = [6, 6, 6, 6, 6];
+    }
+
+    // Fund proposal
+    if (proposalData.proposalType === 1) {
+        for (let i = 0; i < assessCount; i += 1) {
+            const assessVote = VoteraVoteFactory.connect(voteraVote.address, validators[i]);
+            await assessVote.submitAssess(proposalID, passAssessResult);
+        }
+
+        // wait unit assessEnd
+        await network.provider.send("evm_increaseTime", [15000]);
+        await network.provider.send("evm_mine");
+
+        await voteraVote.countAssess(proposalID);
+
+        // wait until startTime
+        await network.provider.send("evm_increaseTime", [15000]);
+        await network.provider.send("evm_mine");
+    } else {
+        // wait until startTime
+        await network.provider.send("evm_increaseTime", [30000]);
+        await network.provider.send("evm_mine");
+    }
+}
+
+export async function countVote(
+    proposalID: string,
+    positive: number,
+    negative: number,
+    blank: number
+): Promise<number[]> {
+    const voterCount = positive + negative + blank;
+
+    // setup votes
+    const choices: number[] = [];
+    const nonces: number[] = [];
+    const expectVoteCounts: number[] = [0, 0, 0];
+
+    // set positive votes
+    for (let i = 0; i < positive; i += 1) {
+        choices.push(1);
+        nonces.push(i + 1);
+        expectVoteCounts[1] += 1;
+    }
+
+    // set negative votes
+    for (let i = positive; i < positive + negative; i += 1) {
+        choices.push(2);
+        nonces.push(i + 1);
+        expectVoteCounts[2] += 1;
+    }
+
+    // set blank (= abstention) votes
+    for (let i = positive + negative; i < voterCount; i += 1) {
+        choices.push(0);
+        nonces.push(i + 1);
+        expectVoteCounts[0] += 1;
+    }
+
+    let submitBallotTx;
+    for (let i = 0; i < voterCount; i += 1) {
+        const commitment = await makeCommitment(
+            voteraVote.address,
+            proposalID,
+            validators[i].address,
+            choices[i],
+            nonces[i]
+        );
+        const signature = await signCommitment(voteManager, proposalID, validators[i].address, commitment);
+
+        const ballotVote = VoteraVoteFactory.connect(voteraVote.address, validators[i]);
+        submitBallotTx = await ballotVote.submitBallot(proposalID, commitment, signature);
+    }
+
+    expect(await voteraVote.getBallotCount(proposalID)).equal(voterCount);
+
+    if (submitBallotTx) {
+        await submitBallotTx.wait();
+    }
+
+    await network.provider.send("evm_increaseTime", [30000]);
+    await network.provider.send("evm_mine");
+
+    for (let i = 0; i < voterCount; i += 1) {
+        const ballotAddr = await voteraVote.getBallotAt(proposalID, i);
+        const ballot = await voteraVote.getBallot(proposalID, ballotAddr);
+        expect(ballot.key).equal(validators[i].address);
+    }
+
+    // wait until openTime
+    await network.provider.send("evm_increaseTime", [30]);
+    await network.provider.send("evm_mine");
+
+    await voteraVote.revealBallot(
+        proposalID,
+        validators.slice(0, voterCount).map((v) => v.address),
+        choices,
+        nonces
+    );
+    await voteraVote.countVote(proposalID);
+
+    return expectVoteCounts;
+}
+
+export async function countVoteResult(proposalID: string, votingResult: boolean): Promise<number[]> {
+    let positive: number = 0;
+    let negative: number = 0;
+    if (votingResult) {
+        positive = validators.length;
+    } else {
+        negative = validators.length;
+    }
+    return countVote(proposalID, positive, negative, 0);
+}
+
+export async function processVote(
+    proposalID: string,
+    positive: number,
+    negative: number,
+    blank: number
+): Promise<number[]> {
+    await assessProposal(proposalID, true);
+    return countVote(proposalID, positive, negative, blank);
 }


### PR DESCRIPTION
There was too much boilerplate code, making the readability and creating new test code so diffilcut.
This is to simplify the test code by moving the same codes into the `VoteHelper` module.

Part of #11 

테스트 코드의 중복 코드를 없애는 작업을 진행하였습니다. 테스트 코드의 내용이나 스마트 컨트랙트는 변경하지 않았습니다. 업그레이드 가능 컨트랙트를 진행하는 과정에서 다음 작업의 편의를 위해서 진행하였습니다.

CommonsBudget.test.ts와 VoteraVote.test.ts는 코드가 복잡하여 나중에 다시 진행할 예정입니다.

스마트 컨트랙트의 알고리즘과 관련이 없는 변경이므로, 다른 코멘트가 없으면 오늘중으로 제가 머지하도록 하겠습니다.