### PR TITLE
Owner can allow funding anytime

### DIFF
--- a/contracts/CommonsStorage.sol
+++ b/contracts/CommonsStorage.sol
@@ -255,7 +255,9 @@ contract CommonsStorage is ICommonsStorage {
     }
 
     function setFundingAllowed(bytes32 _proposalID, bool allow) external onlyCommonsBudget {
-        require(block.timestamp - proposalMaps[_proposalID].countingFinishTime < 86400, "InvalidTime");
+        require(proposalMaps[_proposalID].fundWithdrawn == false, "W09");
+        require(allow == true || block.timestamp - proposalMaps[_proposalID].countingFinishTime < 86400, "InvalidTime");
+
         proposalMaps[_proposalID].fundingAllowed = allow;
     }
 


### PR DESCRIPTION
The owner of tha CommonsBudget contract can allow funding anytime for the proposal for which the funding is refused.

거부권에 의해서 인출이 거부된 제안에 대한 거부권 취소의 기한을 없앤다.

Fixes #34 